### PR TITLE
Copy IP Address on badge click

### DIFF
--- a/server-ip/background.js
+++ b/server-ip/background.js
@@ -38,7 +38,10 @@ chrome.browserAction.onClicked.addListener(function (tab) {
 		tab_changed_now_update(tab.id);
 		chrome.tabs.sendMessage(tab.id, {'toggle':true}, function () {});
 	});
-	copyToClipboard(ipToCopy);
+	sips = JSON.parse(localStorage.getItem('sips')) || {};
+	if (sips.cpip) {
+		copyToClipboard(ipToCopy);
+	}
 });
 
 // response to the content script executed for the page

--- a/server-ip/background.js
+++ b/server-ip/background.js
@@ -9,6 +9,7 @@ function set_badge(ip) {
 		bdg = mnems[ip].mnem;
 	}
 	chrome.browserAction.setBadgeText({'text':bdg});
+	ipToCopy = ip;
 }
 
 function tab_changed_now_update (tab_id) {
@@ -19,12 +20,25 @@ function tab_changed_now_update (tab_id) {
 	});
 }
 
+function copyToClipboard( text ){
+    var copyDiv = document.createElement('div');
+    copyDiv.contentEditable = true;
+    document.body.appendChild(copyDiv);
+    copyDiv.innerHTML = text;
+    copyDiv.unselectable = "off";
+    copyDiv.focus();
+    document.execCommand('SelectAll');
+    document.execCommand("Copy", false, null);
+    document.body.removeChild(copyDiv);
+}
+
 // extension button clicked, make sure badge is correct and toggle ip address on page
 chrome.browserAction.onClicked.addListener(function (tab) {
 	chrome.tabs.getSelected(null, function (tab) {
 		tab_changed_now_update(tab.id);
 		chrome.tabs.sendMessage(tab.id, {'toggle':true}, function () {});
 	});
+	copyToClipboard(ipToCopy);
 });
 
 // response to the content script executed for the page

--- a/server-ip/manifest.json
+++ b/server-ip/manifest.json
@@ -3,7 +3,7 @@
   "version": "2.1.1",
   "description": "View Server IP address or alias",
   "background": { "scripts": ["background.js"] },
-  "permissions": ["webRequest","<all_urls>","tabs"],
+  "permissions": ["webRequest","<all_urls>","tabs","clipboardWrite"],
   "options_page": "options.html",
   "browser_action" : {
 	  "default_title"	: "ServerIP",

--- a/server-ip/options.html
+++ b/server-ip/options.html
@@ -25,6 +25,9 @@
 		<div class="hover-box">
 			<p for="hb"><input type="checkbox" name="hb" id="hb" value="show_hb" />Checking here will display the entire IP address on the page you are viewing in the upper left/right corner for ease of viewing. Note that at any time the full ip display can be toggled by clicking on the extension button in Chrome, regardless of this setting.</p>
 		</div>
+		<div class="copy-ip">
+			<p for="cpip"><input type="checkbox" name="cpip" id="cpip" value="copy_ip" />Checking here will cause the ip address of the current tab to be copied to the clipboard by clicking the extension button.</p>
+		</div>
 		<div>
 			<p>Delete the local storage for all URL, IP combinations. This is harmless, although the extension will 'lose track' of any currently open tabs. It is really only helpful if you think the local storage is getting too large (based on how many different sites you visit).</p>
 			<button id="del_ls">Delete</button>

--- a/server-ip/options.js
+++ b/server-ip/options.js
@@ -22,6 +22,7 @@
 		add_btn = document.getElementById('add_mnem'),
 		rm_btns, rb_i = 0, rb_len,
 		hover_box = document.getElementById('hb'),
+		copy_ip = document.getElementById('cpip'),
 		del_ls_btn = document.getElementById('del_ls');
 
 	function update_obj(name, obj) {
@@ -157,6 +158,17 @@
 			sips.hb = true;
 		} else {
 			sips.hb = false;
+		}
+		update_sips();
+	});
+
+	// set up checkbox to save value of copy_ip
+	copy_ip.checked = !! (sips && sips.cpip);
+	copy_ip.addEventListener('click', function (e) {
+		if (this.checked) {
+			sips.cpip = true;
+		} else {
+			sips.cpip = false;
 		}
 		update_sips();
 	});


### PR DESCRIPTION
This modification provides an option for users to have the ip address of the current tab copied to the clipboard when they click the extension badge icon.

It provides the functionality I requested in issue #4:
https://github.com/jcottrell/ServerIP/issues/4
